### PR TITLE
Add -c concurrency option to kitchen_ci rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task(:kitchen) do
 end
 
 task(:kitchen_ci) do
-  sh 'source /opt/test-kitchen/kitchen_wrapper.sh && bundle exec kitchen test'
+  sh 'source /opt/test-kitchen/kitchen_wrapper.sh && bundle exec kitchen test -c'
 end
 
 task ci: [:berks, :spec, :kitchen_ci]


### PR DESCRIPTION
Runs test suites in parallel rather than serially, which on Jenkins
means creating multiple instances on GCE.

[ID-1346]