### PR TITLE
Replace vmware kitchen provider with virtualbox

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: vagrant
-  provider: vmware_fusion
+  provider: virtualbox
 
 provisioner:
   name: chef_zero


### PR DESCRIPTION
Vmware_fusion wasn't used by anyone on the team, so default to the only
provider in use.

[ID-1342]