### PR TITLE
Id 1519 remove rspec its

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'bundler/setup'
 require 'chefspec'
 require 'chefspec/berkshelf'
 require 'fauxhai'
-require 'rspec/its'
 
 RSpec.configure do |config|
   config.platform = 'centos'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'bundler/setup'
 require 'chefspec'
 require 'chefspec/berkshelf'
-require 'fauxhai'
 
 RSpec.configure do |config|
   config.platform = 'centos'


### PR DESCRIPTION
Both gems are pulled in as dependencies for chef 13 and chefspec 7.x, but not for the latest versions of chef and chefspec which will break our tests.

[ID-1519]

[ID-1519]: https://intoximeters.atlassian.net/browse/ID-1519