### PR TITLE
Initial commit of Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'chef-packer-ci'
+      yamlFile 'jenkins-pod.yaml'
+    }
+  }
+  options {
+    retry(2)
+    timestamps()
+  }
+  stages {
+    stage('Build') {
+      steps {
+        container('chef-packer-ci') {
+          sh """
+#!/bin/bash -ex
+
+export PATH=/opt/intox-ruby26/bin:$PATH
+
+# Whitespace check
+git diff --check
+
+# Merge in master
+git merge --no-commit origin/master || (git reset --hard HEAD; git clean -f; echo CANNOT MERGE MASTER)
+
+bundle install --path vendor/gems
+bundle exec berks install
+bundle exec rake ci
+          """
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      slackSend channel: '#ops-notifications', color: 'danger', message: "${env.JOB_NAME} - #${env.BUILD_NUMBER} ${currentBuild.currentResult} after ${currentBuild.durationString} (<${env.BUILD_URL}|Open>)"
+    }
+    unstable {
+      slackSend channel: '#ops-notifications', color: 'warning', message: "${env.JOB_NAME} - #${env.BUILD_NUMBER} ${currentBuild.currentResult} after ${currentBuild.durationString} (<${env.BUILD_URL}|Open>)"
+    }
+    success {
+      slackSend channel: '#ops-notifications', color: 'good', message: "${env.JOB_NAME} - #${env.BUILD_NUMBER} ${currentBuild.currentResult} after ${currentBuild.durationString} (<${env.BUILD_URL}|Open>)"
+    }
+  }
+}
+

--- a/jenkins-pod.yaml
+++ b/jenkins-pod.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Pod
+spec:
+  imagePullSecrets:
+    - name: intox-gcr
+  containers:
+  # A container named 'jnlp' must be defined here if we want to use multiple
+  # containers.  A pod template added to the global config for the kubernetes
+  # plugin will be ignored, which isn't clear from the plugin documentation.
+  - name: jnlp
+    image: jenkins/jnlp-slave
+    # The jnlp java process seems to consistently use around 200MB of RAM and
+    # probably varies less in memory usage than the other containers.  The CPU
+    # usage is more bursty, with a lot of activity when the container spins up,
+    # then mostly idle until the build ends and it's destroyed.
+    resources:
+      limits:
+        cpu: "1000m"
+        memory: "400Mi"
+      requests:
+        cpu: "50m"
+        memory: "200Mi"
+  - name: chef-packer-ci
+    image: us.gcr.io/intox-gcloud/base-ci:latest
+    # The memory request is a bit on the high end of expected usage, with the
+    # limit being a more or less arbitrary guess at what could be expected with
+    # a memory leak of some kind along with the amount of RAM we could afford
+    # to spare in our k8s cluster when the maximum number of jobs are running
+    # on jenkins.
+    resources:
+      limits:
+        cpu: "1000m"
+        memory: "2000Mi"
+      requests:
+        cpu: "500m"
+        memory: "1000Mi"
+    tty: true
+    volumeMounts:
+    - mountPath: /home/jenkins/.ssh
+      name: ssh
+    - mountPath: /home/jenkins/.chef
+      name: chef
+    - mountPath: /opt/test-kitchen
+      name: test-kitchen
+  volumes:
+  - name: chef
+    secret:
+      secretName: chef
+  - name: ssh
+    secret:
+      secretName: ssh
+  - name: test-kitchen
+    secret:
+      secretName: test-kitchen


### PR DESCRIPTION
Adds the ability to manage CI jobs in jenkins via the kubernetes plugin.
The plugin is technically compatible with freestyle jobs, but only with
a limited set of features, so the plan is to switch to using multibranch
pipelines for each project, which will create new jobs for each github
branch, and use a Jenkinsfile for job configuration rather than relying
on lakitu to generate this for each new job/branch.

A few other things to note...

The container resource limits/requests are an initial best guess at
values that will prevent any pods created by jenkins from overloading
our k8s cluster.  The values chosen were based on a mix of testing and
guesswork, and are expected to be updated once we have more data in the
future.

Secrets required for chef cookbook CI builds are 'chef', which includes
the 'jenkins-agent' chef client key required for connecting to the chef
server, and the 'ssh' and 'test-kitchen' secrets, which are likely only
temporary and will be replaced by IAM roles added to jenkins when we
move from using google for test-kitchen to AWS.

[ID-1574]

[ID-1574]: https://intoximeters.atlassian.net/browse/ID-1574