### PR TITLE
Id 1602 disable concurrent builds

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -10,4 +10,4 @@ GRAPH
     ark (>= 0.0.0)
   seven_zip (3.1.2)
     windows (>= 0.0.0)
-  windows (6.0.1)
+  windows (7.0.0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
     }
   }
   options {
+    disableConcurrentBuilds()
     retry(2)
     timestamps()
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
   agent {
     kubernetes {
-      label 'chef-packer-ci'
       yamlFile 'jenkins-pod.yaml'
     }
   }


### PR DESCRIPTION
Multiple fixes for the Jenkinsfile:

- Removes a k8s label that was causing overlapping pod/build names for different branches
- Adds disableConcurrentBuilds() to prevent multiple pushes of the same branch to run builds concurrently, which can cause issues with the github build status

[ID-1602]

[ID-1602]: https://intoximeters.atlassian.net/browse/ID-1602