### PR TITLE
Update jenkins jnlp docker image name

### DIFF
--- a/jenkins-pod.yaml
+++ b/jenkins-pod.yaml
@@ -8,7 +8,7 @@ spec:
   # containers.  A pod template added to the global config for the kubernetes
   # plugin will be ignored, which isn't clear from the plugin documentation.
   - name: jnlp
-    image: jenkins/jnlp-slave
+    image: jenkins/inbound-agent
     # The jnlp java process seems to consistently use around 200MB of RAM and
     # probably varies less in memory usage than the other containers.  The CPU
     # usage is more bursty, with a lot of activity when the container spins up,


### PR DESCRIPTION
From https://hub.docker.com/r/jenkins/jnlp-slave/: "Warning! This image
used to be published as jenkinsci/jnlp-slave and jenkins/jnlp-slave.
These images are deprecated, use jenkins/inbound-agent."

[ID-1733]

[ID-1733]: https://intoximeters.atlassian.net/browse/ID-1733